### PR TITLE
Handle multiple call paths for same code

### DIFF
--- a/functionid/build.gradle
+++ b/functionid/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'application'
 }
 
 group 'org.example'
@@ -24,3 +25,5 @@ dependencies {
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
+
+mainClassName = 'tech.pegasys.poc.witnesscodeanalysis.ByteCodeDump'

--- a/functionid/src/main/java/tech/pegasys/poc/witnesscodeanalysis/functionid/FunctionIdProcess.java
+++ b/functionid/src/main/java/tech/pegasys/poc/witnesscodeanalysis/functionid/FunctionIdProcess.java
@@ -27,6 +27,7 @@ public class FunctionIdProcess {
     CodePaths codePaths = new CodePaths(this.code, this.jumpDests);
     codePaths.findFunctionBlockCodePaths(this.endOfFunctionIdBlock);
     codePaths.findCodeSegmentsForFunctions();
+
     codePaths.showAllCodePaths();
     boolean codePathsValid = codePaths.validateCodeSegments(this.endOfCode);
     LOG.info("Code Paths Valid: {}", codePathsValid);

--- a/functionid/src/main/java/tech/pegasys/poc/witnesscodeanalysis/vm/MessageFrame.java
+++ b/functionid/src/main/java/tech/pegasys/poc/witnesscodeanalysis/vm/MessageFrame.java
@@ -241,6 +241,10 @@ public class MessageFrame implements Cloneable {
     return stack.pop();
   }
 
+  public OperandStack getCopyOfStack() {
+    return (OperandStack) ((PreAllocatedOperandStack) this.stack).clone();
+  }
+
   /**
    * Removes the corresponding number of items from the top of the stack.
    *

--- a/functionid/src/main/java/tech/pegasys/poc/witnesscodeanalysis/vm/PreAllocatedOperandStack.java
+++ b/functionid/src/main/java/tech/pegasys/poc/witnesscodeanalysis/vm/PreAllocatedOperandStack.java
@@ -111,8 +111,14 @@ public class PreAllocatedOperandStack implements OperandStack, Cloneable {
   }
 
   @Override
-  protected Object clone() throws CloneNotSupportedException {
-    PreAllocatedOperandStack cloneObj = (PreAllocatedOperandStack) super.clone();
+  protected Object clone() {
+    PreAllocatedOperandStack cloneObj = null;
+    try {
+      cloneObj = (PreAllocatedOperandStack) super.clone();
+    } catch (CloneNotSupportedException ex) {
+      // Object will support clone.
+      throw new RuntimeException(ex);
+    }
     cloneObj.entries = new Bytes32[this.entries.length];
     for (int i = 0; i < this.entries.length; i++) {
       cloneObj.entries[i] = this.entries[i];


### PR DESCRIPTION
Added ability to handle case where the same code is called via more than one call path. That is, either the same previous code segment with a different call stack or a different previous code segment (with a same or different call stack).