### PR TITLE
Improve handling of older solidity variants. 

### DIFF
--- a/common/src/main/java/tech/pegasys/poc/witnesscodeanalysis/common/SimpleAnalysis.java
+++ b/common/src/main/java/tech/pegasys/poc/witnesscodeanalysis/common/SimpleAnalysis.java
@@ -80,7 +80,7 @@ public class SimpleAnalysis {
       }
       pc = pc + curOp.getOpSize();
       if (pc > probableEndOfCode) {
-        throw new Error("No REVERT found in code");
+        throw new Error("No CALLDATALOAD found in code");
       }
     }
 
@@ -93,7 +93,9 @@ public class SimpleAnalysis {
         // Don't try to process any further.
         return functionIds;
       }
-      if (curOp.getOpcode() == RevertOperation.OPCODE) {
+      if ((curOp.getOpcode() == RevertOperation.OPCODE) ||
+          (curOp.getOpcode() == StopOperation.OPCODE) ||
+          (curOp.getOpcode() == ReturnOperation.OPCODE)) {
         done = true;
       } else if (curOp.getOpcode() == PushOperation.PUSH4_OPCODE) {
         Bytes functionId = code.slice(pc + 1, 4);
@@ -101,7 +103,7 @@ public class SimpleAnalysis {
       }
       pc = pc + curOp.getOpSize();
       if (pc > probableEndOfCode) {
-        throw new Error("No REVERT found in code");
+        throw new Error("No REVERT, RETURN or STOP found in code");
       }
     }
     return functionIds;
@@ -233,7 +235,8 @@ public class SimpleAnalysis {
         }
       }
     }
-    this.endOfCode = pc;
+    // End of code detection is not reliable. Hence, just have end of code as the length of the code.
+    //this.endOfCode = pc;
 
     this.endOfCodeDetected = true;
   }

--- a/evm/src/main/java/tech/pegasys/poc/witnesscodeanalysis/vm/operations/DupOperation.java
+++ b/evm/src/main/java/tech/pegasys/poc/witnesscodeanalysis/vm/operations/DupOperation.java
@@ -34,4 +34,9 @@ public class DupOperation extends AbstractOperation {
     frame.pushStackItem(frame.getStackItem(index - 1));
     return UInt256.ZERO;
   }
+
+  public static boolean isADupOpCode(int opCode) {
+    return (opCode >= 0x80 && opCode <= 0x8f);
+  }
+
 }

--- a/functionid/src/main/java/tech/pegasys/poc/witnesscodeanalysis/functionid/CodePaths.java
+++ b/functionid/src/main/java/tech/pegasys/poc/witnesscodeanalysis/functionid/CodePaths.java
@@ -211,11 +211,11 @@ public class CodePaths {
       }
       pc = next;
 
-      if (pc > endOfCodeOffset) {
+      if (pc > endOfCodeOffset+1) {
         LOG.error("Gone past end of code: pc: {}, end of code: {}", pc, endOfCodeOffset);
         throw new RuntimeException("Gone past end of code");
       }
-      if (pc == endOfCodeOffset) {
+      if (pc == endOfCodeOffset || pc == endOfCodeOffset+1) {
         done = true;
       }
     }

--- a/functionid/src/main/java/tech/pegasys/poc/witnesscodeanalysis/functionid/CodeVisitor.java
+++ b/functionid/src/main/java/tech/pegasys/poc/witnesscodeanalysis/functionid/CodeVisitor.java
@@ -21,6 +21,7 @@ import tech.pegasys.poc.witnesscodeanalysis.vm.MainnetEvmRegistries;
 import tech.pegasys.poc.witnesscodeanalysis.vm.MessageFrame;
 import tech.pegasys.poc.witnesscodeanalysis.vm.OperandStack;
 import tech.pegasys.poc.witnesscodeanalysis.vm.Operation;
+import tech.pegasys.poc.witnesscodeanalysis.vm.operations.DupOperation;
 import tech.pegasys.poc.witnesscodeanalysis.vm.operations.EqOperation;
 import tech.pegasys.poc.witnesscodeanalysis.vm.operations.InvalidOperation;
 import tech.pegasys.poc.witnesscodeanalysis.vm.operations.JumpDestOperation;
@@ -240,6 +241,11 @@ public class CodeVisitor {
       this.foundPush4OpCode = false;
       if (opCode == EqOperation.OPCODE) {
         this.foundEqOpCode = true;
+      }
+      else if (DupOperation.isADupOpCode(opCode)) {
+        // Some times there is a Dup2 between the PUSH4 and the EQ.
+        // Stay in the "waiting for EQ opcode state"
+        this.foundPush4OpCode = true;
       }
     }
     if (opCode == PushOperation.PUSH4_OPCODE) {

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -17,9 +17,10 @@ dependencies {
     compile project (':strictfixed')
     compile project (':jumpdest')
     compile project (':functionid')
+    compile project (':bytecodedump')
 
     // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.2'
 }
 
-mainClassName = 'tech.pegasys.poc.witnesscodeanalysis.ByteCodeDump'
+mainClassName = 'tech.pegasys.poc.witnesscodeanalysis.WitnessCodeAnalysis'

--- a/main/src/main/java/tech/pegasys/poc/witnesscodeanalysis/WitnessCodeAnalysis.java
+++ b/main/src/main/java/tech/pegasys/poc/witnesscodeanalysis/WitnessCodeAnalysis.java
@@ -16,6 +16,7 @@ package tech.pegasys.poc.witnesscodeanalysis;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.poc.witnesscodeanalysis.bytecodedump.ByteCodeDump;
 import tech.pegasys.poc.witnesscodeanalysis.common.ContractData;
 import tech.pegasys.poc.witnesscodeanalysis.processing.FixedSizeProcessing;
 import tech.pegasys.poc.witnesscodeanalysis.processing.FunctionIdProcessing;
@@ -34,7 +35,7 @@ public class WitnessCodeAnalysis {
   public static boolean JUMPDEST = false;
   public static boolean FIXEDSIZE = false;
   public static boolean STRICTFIXEDSIZE = false;
-  public static boolean FUNCTIONID = false;
+  public static boolean FUNCTIONID = true;
 
   private MainNetContractDataSet dataSet;
   private SimpleProcessing simpleProcessing;
@@ -57,7 +58,7 @@ public class WitnessCodeAnalysis {
     int count = 0;
     ContractData contractData;
     while ((contractData = this.dataSet.next()) != null) {
-      //contractData.showInfo(count);
+      contractData.showInfo(count);
       process(contractData);
       count++;
 
@@ -117,6 +118,25 @@ public class WitnessCodeAnalysis {
     }
     closeAll();
   }
+
+
+  public void dumpOne(int theOne) throws Exception {
+    int count = 0;
+    ContractData contractData;
+    while ((contractData = this.dataSet.next()) != null) {
+      if (count == theOne) {
+        contractData.showInfo(count);
+        Bytes code = Bytes.fromHexString(contractData.getCode());
+        ByteCodeDump dump = new ByteCodeDump(code);
+        dump.showBasicInfo();
+        dump.dumpContract();
+        break;
+      }
+      count++;
+    }
+    closeAll();
+  }
+
 
   public void process(ContractData contractData) {
     Bytes code = Bytes.fromHexString(contractData.getCode());
@@ -182,8 +202,9 @@ public class WitnessCodeAnalysis {
     WitnessCodeAnalysis witnessCodeAnalysis = new WitnessCodeAnalysis();
 
     // NOTE: Can only choose one of these.
-//    witnessCodeAnalysis.analyseUpTo(10000);
-//    witnessCodeAnalysis.analyseOne(561648);
+    //witnessCodeAnalysis.analyseUpTo(541);
+    //witnessCodeAnalysis.dumpOne(541);
+//    witnessCodeAnalysis.analyseOne(541);
 
 //    witnessCodeAnalysis.analyseDeployedBlockNumbers(9999990, 10000000);
 

--- a/main/src/main/java/tech/pegasys/poc/witnesscodeanalysis/processing/FunctionIdProcessing.java
+++ b/main/src/main/java/tech/pegasys/poc/witnesscodeanalysis/processing/FunctionIdProcessing.java
@@ -39,7 +39,7 @@ public class FunctionIdProcessing extends AbstractProcessing {
   @Override
   protected void executeProcessing(Bytes code) throws Exception {
     LOG.trace(" Function Id Analysis");
-    AuxData auxData = new AuxData(code);
+//    AuxData auxData = new AuxData(code);
     SimpleAnalysis simple = new SimpleAnalysis(code);
 
     if (simple.getEndOfFunctionIdBlock() == -1) {


### PR DESCRIPTION
Improve handling of end of code and the first function call for older Solidity variants.
Allow dump code to be called on a specific contract number from the data file.
Configure build so the correct executable class is targeted for Code Witness Analysis.

Signed-off-by: Peter  Robinson <drinkcoffee@eml.cc>